### PR TITLE
Use path_expander instead of the filter_files method.

### DIFF
--- a/lib/pronto/flay.rb
+++ b/lib/pronto/flay.rb
@@ -4,8 +4,13 @@ require 'flay'
 module Pronto
   class Flay < Runner
     def run
-      files = ruby_patches.map(&:new_file_full_path)
-      files = ::Flay.filter_files(files)
+      args = ruby_patches.map(&:new_file_full_path)
+
+      extensions = ["rb"] + ::Flay.load_plugins
+      glob = "**/*.{#{extensions.join ','}}"
+
+      expander = PathExpander.new args, glob
+      files = expander.filter_files expander.process, ::Flay::DEFAULT_IGNORE
 
       if files.any?
         flay.process(*files)


### PR DESCRIPTION
Needed because of [this commit](https://github.com/seattlerb/flay/commit/4781d22de036dcb6976ff5c04d38569b9912faae) to Flay.
